### PR TITLE
7 Add Event Service and Dedicated Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,34 +18,45 @@ You can use the `rerun` gem to help reload your Sinatra project without having t
 - Use the command `rerun 'ruby app.rb'` to start the rerun server
 - Stop the rerun server with `control + c`
 
-# Testing
+## Testing
 Testing is done with the Rspec testing library.
 
-## Run all tests
+### Run all tests
 Use the command `rspec` to run all tests.
 
-## Run single tests
+### Run single tests
 Use the command `rspec /spec/<path>/<to>/<individual>/<test>` to run a single test.
 
-## Travis-CI
+### Travis-CI
 All tests are automatically run with [Travis CI](https://travis-ci.com/) after each pushed branch update.
 
-# Technologies
+## Endpoints
 
-## Languages / Frameworks
+### ISS Location
+The `/iss` endpoint provides the location information used for tracking the ISS. This information is provided by the [Where is the ISS at? API](https://wheretheiss.at/w/developer).
+
+### Events
+The `/events` endpoint provides the natural disaster data - or events - from the [Nasa Earth Observatory Natural Event Tracker API](https://eonet.sci.gsfc.nasa.gov/docs/v2.1).
+
+### Observatories
+The `/observatories` endpoint provides the location data for Nasa Ground Station Observatoreis which is provided by the [Nasa Satellite Situation Center API](https://sscweb.gsfc.nasa.gov/WebServices/REST/).
+
+## Technologies
+
+### Languages / Frameworks
 - Ruby
 - Sinatra
 
-## Libraries
+### Libraries
 - [Faraday](https://lostisland.github.io/faraday/)
 
-## Testing
+### Testing
 - Rspec
 - Travis-CI
 
-## APIs
+### APIs
 This data in this project comes from the Where's the ISS at? and the NASA Open API Service.
 
-# Requirements
+## Requirements
 - Ruby 2.7.1 or compatiable version
 - Sinatra 2.0.8.1

--- a/app.rb
+++ b/app.rb
@@ -6,7 +6,17 @@ get '/' do
   "Hello World!"
 end
 
-get '/response' do
-  response = ResponseService.response
+get '/iss' do
+  response = ResponseService.iss_location_response
+  response.to_json
+end
+
+get '/events' do
+  response = ResponseService.events_response
+  response.to_json
+end
+
+get '/observatories' do
+  response = ResponseService.observatories_response
   response.to_json
 end

--- a/app/services/nasa_event_service.rb
+++ b/app/services/nasa_event_service.rb
@@ -1,0 +1,21 @@
+require 'faraday'
+
+class NasaEventService
+
+  def self.event_locations
+    response = conn.get() do |req|
+        req.params['status'] = 'open'
+    end
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  private
+
+    def self.conn
+      url = 'https://eonet.sci.gsfc.nasa.gov/api/v3/events/geojson'
+      Faraday.new(url, headers: {'Accept' => 'application/json'}) do |f|
+        f.adapter Faraday.default_adapter
+      end
+    end
+
+end

--- a/app/services/response_service.rb
+++ b/app/services/response_service.rb
@@ -1,11 +1,22 @@
 class ResponseService
-
-  def self.response
+  def self.iss_location_response
     data = Hash.new
     data[:data] = Hash.new
     data[:data][:IssLocation] = current_iss_location
-    data[:data][:NasaObservatories] = nasa_observatory_locations
+    return data
+  end
+  
+  def self.events_response
+    data = Hash.new
+    data[:data] = Hash.new
     data[:data][:NasaEvents] = nasa_event_locations
+    return data
+  end
+
+  def self.observatories_response
+    data = Hash.new
+    data[:data] = Hash.new
+    data[:data][:NasaObservatories] = nasa_observatory_locations
     return data
   end
 

--- a/app/services/response_service.rb
+++ b/app/services/response_service.rb
@@ -5,18 +5,26 @@ class ResponseService
     data[:data] = Hash.new
     data[:data][:IssLocation] = current_iss_location
     data[:data][:NasaObservatories] = nasa_observatory_locations
+    data[:data][:NasaEvents] = nasa_event_locations
     return data
   end
 
   private
   
     def self.current_iss_location
-      response = IssService.iss_location
+      IssService.iss_location
     end
 
     def self.nasa_observatory_locations
-      response = NasaObservatoryService.observatory_locations
-      response[:GroundStation][1]
+      observatories = NasaObservatoryService.observatory_locations
+      observatories[:GroundStation][1]
+    end
+
+    def self.nasa_event_locations
+      all_events = NasaEventService.event_locations
+      return all_events[:features].map do |event|
+        event if event[:geometry][:type].include?("Point")
+      end
     end
 
 end

--- a/spec/app/response_spec.rb
+++ b/spec/app/response_spec.rb
@@ -11,10 +11,13 @@ describe '/response endpoint' do
     expect(response).to have_key :data
     expect(response[:data]).to have_key :IssLocation
     expect(response[:data][:IssLocation]).to be_a Hash
+
     expect(response[:data]).to have_key :NasaObservatories
     expect(response[:data][:NasaObservatories]).to be_an Array
-    
     expect(response[:data]).not_to have_key "GroundStation"
     expect(response[:data][:NasaObservatories][1]).not_to have_key "GroundStation"
+
+    expect(response[:data]).to have_key :NasaEvents
+    expect(response[:data][:NasaEvents]).to be_an Array
   end
 end

--- a/spec/app/response_spec.rb
+++ b/spec/app/response_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe '/response endpoint' do
-  it 'the response generates the proper keys' do
-    get '/response'
+describe '/iss endpoint' do
+  it 'the response generates the proper iss location container' do
+    get '/iss'
 
     expect(last_response).to be_ok
     
@@ -11,13 +11,29 @@ describe '/response endpoint' do
     expect(response).to have_key :data
     expect(response[:data]).to have_key :IssLocation
     expect(response[:data][:IssLocation]).to be_a Hash
+  end
+
+  it 'the response generates the proper events container' do
+    get '/events'
+
+    expect(last_response).to be_ok
+    
+    response = JSON.parse(last_response.body, symbolize_names: true)
+
+    expect(response[:data]).to have_key :NasaEvents
+    expect(response[:data][:NasaEvents]).to be_an Array
+  end
+
+  it 'the response generates the proper observatory container' do
+    get '/observatories'
+
+    expect(last_response).to be_ok
+    
+    response = JSON.parse(last_response.body, symbolize_names: true)
 
     expect(response[:data]).to have_key :NasaObservatories
     expect(response[:data][:NasaObservatories]).to be_an Array
     expect(response[:data]).not_to have_key "GroundStation"
     expect(response[:data][:NasaObservatories][1]).not_to have_key "GroundStation"
-
-    expect(response[:data]).to have_key :NasaEvents
-    expect(response[:data][:NasaEvents]).to be_an Array
   end
 end

--- a/spec/services/nasa_event_service_spec.rb
+++ b/spec/services/nasa_event_service_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe NasaEventService do
+  it 'fetches the location of Nasa Events from the Nasa API' do
+    nasa_event_service = NasaEventService.new
+    
+    expect(nasa_event_service).to be_a NasaEventService
+    
+    nasa_event_service_response = NasaEventService.event_locations
+
+    expect(nasa_event_service_response).to have_key :type
+    expect(nasa_event_service_response[:type]).to eq 'FeatureCollection'
+    expect(nasa_event_service_response).to have_key :features
+    expect(nasa_event_service_response[:features]).to be_an Array
+    expect(nasa_event_service_response[:features][0]).to be_a Hash
+    expect(nasa_event_service_response[:features][0]).to have_key :type
+    expect(nasa_event_service_response[:features][0][:type]).to eq 'Feature'
+    expect(nasa_event_service_response[:features][0][:properties]).to be_a Hash
+    expect(nasa_event_service_response[:features][0][:properties]).to be_a Hash
+    expect(nasa_event_service_response[:features][0][:properties]).to have_key :id
+  end
+end


### PR DESCRIPTION
# PR Documentation

## Fixes #7 

## Type of change
- [ ] :beetle: Bug fix (non-breaking change which fixes an issue)
- [x] :hatching_chick: New feature (non-breaking change which adds functionality)
- [x] :page_with_curl: This change requires a documentation update

## Summary of changes
- Add `EventService` to get the Natural Disaster - or Events- from the [Nasa Earth Observatory Natural Event Tracker API](https://eonet.sci.gsfc.nasa.gov/docs/v2.1).
- Split response endpoints into individual endpoints
- Add endpoint information to `README.md`

## How Has This Been Tested?
- [x] :black_square_button: Integration testing
- [x] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [x] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [x] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes
